### PR TITLE
added an additional typeguard to catch parsed array's in normalizeValue

### DIFF
--- a/src/assetbundles/hommicons/dist/css/HOMMIconsField.css
+++ b/src/assetbundles/hommicons/dist/css/HOMMIconsField.css
@@ -64,9 +64,13 @@
     align-items: flex-start;
 }
 
-.iconpicker-code {
+.homm-iconpicker > .iconpicker-code {
     margin-left: 10px !important;
     width: 200px !important;
+    display: flex;
+    flex-grow: 1;
+    text-align: left;
+    line-height: 1.5em !important;
 }
 
 .iconpicker-msg {

--- a/src/fields/HOMMIconsField.php
+++ b/src/fields/HOMMIconsField.php
@@ -64,13 +64,17 @@ class HOMMIconsField extends Field implements PreviewableFieldInterface
      */
     public function normalizeValue(mixed $value, ?\craft\base\ElementInterface $element = null): mixed
     {
-        if (gettype($value) == 'string') {
+         if (gettype($value) == 'string') {
             if (isset(json_decode($value)->icon)) {
                 return json_decode($value)->icon;
             } else {
                 return $value;
             }
-        } else {
+        } 
+        else if (gettype($value) == 'array') {
+            return $value['icon'];
+        }
+        else {
             return $value;
         }
 

--- a/src/fields/HOMMIconsField.php
+++ b/src/fields/HOMMIconsField.php
@@ -64,17 +64,15 @@ class HOMMIconsField extends Field implements PreviewableFieldInterface
      */
     public function normalizeValue(mixed $value, ?\craft\base\ElementInterface $element = null): mixed
     {
-         if (gettype($value) == 'string') {
+        if (gettype($value) == 'string') {
             if (isset(json_decode($value)->icon)) {
                 return json_decode($value)->icon;
             } else {
                 return $value;
             }
-        } 
-        else if (gettype($value) == 'array') {
+        } elseif (gettype($value) == 'array') {
             return $value['icon'];
-        }
-        else {
+        } else {
             return $value;
         }
 

--- a/src/templates/_components/fields/HOMMIconsField_input.twig
+++ b/src/templates/_components/fields/HOMMIconsField_input.twig
@@ -13,18 +13,17 @@
  */
 #}
 
-{% set value = value ?? '' %}
-{% set iconName = value.icon ?? '' %}
+{% set iconName = value ?? '' %}
 
 <input type="hidden" name="{{ name }}[icon]" class="iconpicker-icon" value="{{ iconName }}">
-<p class="iconpicker-msg homm-iconpicker{% if value == '' %}--empty{% endif %}">
+<p class="iconpicker-msg homm-iconpicker{% if iconName == '' %}--empty{% endif %}">
     <span class="homm-iconpicker">
         <span class="iconpicker-preview">
-           {% for icon in icons %}
-               {% if icon.getFilename(false) == iconName %}
-                   <img src="{{ icon.getUrl() }}" alt="{{ icon.getFilename(false) }}" loading="lazy">
-               {% endif %}
-           {% endfor %}
+            {% for icon in icons %}
+                {% if icon.getFilename(false) == iconName %}
+                    <img src="{{ icon.getUrl() }}" alt="{{ icon.getFilename(false) }}" loading="lazy">
+                {% endif %}
+            {% endfor %}
         </span>
     </span>
     <span class="iconpicker-code">
@@ -42,7 +41,7 @@
                     {% for icon in icons %}
                         {% if icon.folder == 'icons' %}
                             <span data-val="{{ icon.getFilename(false) }}"
-                                  class="{{ value == icon.getFilename(false) ? 'iconpicker--selected' }}"
+                                  class="{{ iconName == icon.getFilename(false) ? 'iconpicker--selected' }}"
                                   title="{{ icon.getFilename(false) }}"
                             >
                                 <img src="{{ icon.getUrl() }}" alt="{{ icon.getFilename(false) }}" loading="lazy">


### PR DESCRIPTION
The icon name gets saved as an array with a single 'icon' attribute. Adding the typeguard on 'normalizeValue' fixes the output, but it still gets saved as an array when selecting...